### PR TITLE
The auth-data module has been successfully converted to Kotlin!

### DIFF
--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/AccessToken.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/AccessToken.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+data class AccessToken(
+    var accessToken: String? = null,
+    var tokenType: TokenTypeEnum? = null,
+    var refreshToken: String? = null,
+    var expiresIn: Int? = null,
+    var idToken: String? = null,
+    var scope: String? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Application.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Application.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.*
+
+data class Application(
+    var id: UUID? = null,
+    var clientId: String? = null,
+    var name: String? = null,
+    var authorizationServerId: UUID? = null,
+    var scopes: List<Scope>? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ApplicationSecret.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ApplicationSecret.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.*
+
+data class ApplicationSecret(
+    var id: UUID? = null,
+    var applicationId: UUID? = null,
+    var authorizationServerId: UUID? = null,
+    var name: String? = null,
+    var applicationSecret: String? = null,
+    var applicationSecretHash: String? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var expiresIn: Int? = 0,
+    var scopes: List<Scope>? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/AuthorizationServer.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/AuthorizationServer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.net.URL
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class AuthorizationServer(
+    var id: UUID? = null,
+    var name: String? = null,
+    var serverUrl: URL? = null,
+    var audience: String? = null,
+    var clientCredentialsTokenExpiration: Long? = null,
+    var authorizationCodeTokenExpiration: Long? = null,
+    var metadata: Metadata? = null,
+    var scopes: List<Scope>? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Client.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Client.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.net.URI
+import java.time.OffsetDateTime
+import java.util.*
+
+data class Client(
+    var id: UUID? = null,
+    var name: String? = null,
+    var authorizationServerId: UUID? = null,
+    var redirectUris: List<URI>? = null,
+    var scopes: List<Scope>? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ClientCode.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ClientCode.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class ClientCode(
+    var id: UUID? = null,
+    var clientId: String? = null,
+    var authorizationServerId: UUID? = null,
+    var createdOn: OffsetDateTime? = null,
+    var redirectUri: String? = null,
+    var scopes: List<Scope>? = null,
+    var state: String? = null,
+    var code: String? = null,
+    var codeChallenge: String? = null,
+    var codeChallengeMethod: String? = null,
+    var userId: UUID? = null,
+    var nonce: String? = null
+) {
+    fun getNonce(): String {
+        return nonce ?: UUID.randomUUID().toString()
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/DiscoveryMethodEnum.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/DiscoveryMethodEnum.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+enum class DiscoveryMethodEnum(private val value: String) {
+    MANUAL("manual"),
+    WELL_KNOWN("well-known");
+
+    fun value(): String = value
+
+    override fun toString(): String = value
+
+    companion object {
+        fun fromString(s: String): DiscoveryMethodEnum {
+            return values().find { it.value == s }
+                ?: throw IllegalArgumentException("Unexpected string value '$s'")
+        }
+
+        fun fromValue(value: String): DiscoveryMethodEnum {
+            return values().find { it.value == value }
+                ?: throw IllegalArgumentException("Unexpected value '$value'")
+        }
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Identifier.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Identifier.kt
@@ -1,0 +1,6 @@
+package com.cartobucket.auth.data.domain
+
+data class Identifier(
+    var system: String? = null,
+    var value: String? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/IdentityProvider.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/IdentityProvider.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class IdentityProvider(
+    var id: UUID? = null,
+    var name: String? = null,
+    var authorizationServerId: UUID? = null,
+    var discoveryMethod: DiscoveryMethodEnum? = null,
+    var discoveryEndpoint: String? = null,
+    var wellKnownEndpoints: WellKnownEndpoints? = null,
+    var clientId: String? = null,
+    var clientSecret: String? = null,
+    var usePkce: Boolean? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/JWK.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/JWK.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+data class JWK(
+    var kid: String? = null,
+    var kty: String? = null,
+    var alg: String? = null,
+    var use: String? = null,
+    var n: String? = null,
+    var e: String? = null,
+    var x5c: MutableList<String>? = null,
+    var x5t: String? = null,
+    var x5tHashS256: String? = null
+) {
+    fun addX5cItem(x5cItem: String): JWK {
+        if (this.x5c == null) {
+            this.x5c = mutableListOf()
+        }
+        this.x5c?.add(x5cItem)
+        return this
+    }
+
+    fun removeX5cItem(x5cItem: String): JWK {
+        this.x5c?.remove(x5cItem)
+        return this
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Metadata.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Metadata.kt
@@ -1,0 +1,7 @@
+package com.cartobucket.auth.data.domain
+
+data class Metadata(
+    var identifiers: List<Identifier>? = null,
+    var schemaValidations: List<SchemaValidation>? = null,
+    var properties: Map<String, Any>? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Page.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Page.kt
@@ -1,0 +1,17 @@
+package com.cartobucket.auth.data.domain
+
+data class Page(val limit: Int, val offset: Int) {
+    init {
+        require(limit > 0) { "Page limit must be > 0 : $limit" }
+        require(limit <= 100) { "Page limit must be <= 100 : $limit" }
+        require(offset >= 0) { "Page offset must be >= 0 : $offset" }
+    }
+
+    fun getNextRowsCount(): Int = (offset + limit) - 1
+    fun offset(): Int {
+        return offset
+    }
+    fun limit(): Int {
+        return limit
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Pair.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Pair.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.cartobucket.auth.data.domain
+
+/**
+ * Utility class representing a pair of values.
+ *
+ * @since 19.0
+ */
+data class Pair<L, R>(val left: L?, val right: R?) {
+    
+    companion object {
+        private val EMPTY: Pair<Any?, Any?> = Pair(null, null)
+        
+        /**
+         * Returns an empty pair.
+         *
+         * @since 19.0
+         */
+        @Suppress("UNCHECKED_CAST")
+        fun <L, R> empty(): Pair<L, R> = EMPTY as Pair<L, R>
+        
+        /**
+         * Constructs a pair with its left value being [left], or returns an empty pair if
+         * [left] is null.
+         *
+         * @return the constructed pair or an empty pair if [left] is null.
+         * @since 19.0
+         */
+        fun <L, R> createLeft(left: L?): Pair<L, R> =
+            if (left == null) empty() else Pair(left, null)
+        
+        /**
+         * Constructs a pair with its right value being [right], or returns an empty pair if
+         * [right] is null.
+         *
+         * @return the constructed pair or an empty pair if [right] is null.
+         * @since 19.0
+         */
+        fun <L, R> createRight(right: R?): Pair<L, R> =
+            if (right == null) empty() else Pair(null, right)
+        
+        /**
+         * Constructs a pair with its left value being [left], and its right value being
+         * [right], or returns an empty pair if both inputs are null.
+         *
+         * @return the constructed pair or an empty pair if both inputs are null.
+         * @since 19.0
+         */
+        fun <L, R> create(left: L?, right: R?): Pair<L, R> =
+            if (left == null && right == null) empty() else Pair(left, right)
+    }
+    
+    override fun toString(): String = "($left, $right)"
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Profile.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Profile.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.*
+
+data class Profile(
+    var id: UUID? = null,
+    var authorizationServerId: UUID? = null,
+    var resource: UUID? = null,
+    var profileType: ProfileType? = null,
+    var profile: Map<String, Any>? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ProfileType.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ProfileType.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+enum class ProfileType {
+    User,
+    Application
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ResourceType.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/ResourceType.kt
@@ -1,0 +1,12 @@
+package com.cartobucket.auth.data.domain
+
+enum class ResourceType {
+    APPLICATIONS,
+    AUTHORIZATION_SERVERS,
+    APPLICATION_SECRETS,
+    CLIENTS,
+    SCHEMAS,
+    SCOPES,
+    TEMPLATES,
+    USERS
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Schema.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Schema.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class Schema(
+    var id: UUID? = null,
+    var authorizationServerId: UUID? = null,
+    var name: String? = null,
+    var jsonSchemaVersion: String? = null,
+    var schema: Map<String, Any>? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/SchemaValidation.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/SchemaValidation.kt
@@ -1,0 +1,10 @@
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class SchemaValidation(
+    var schemaId: UUID? = null,
+    var isValid: Boolean = false,
+    var validatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Scope.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Scope.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.*
+
+data class Scope(
+    var id: UUID? = null,
+    var authorizationServer: AuthorizationServer? = null,
+    var name: String? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as Scope
+        return name == other.name
+    }
+
+    override fun hashCode(): Int = name?.hashCode() ?: 0
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/SigningKey.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/SigningKey.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class SigningKey(
+    var id: UUID? = null,
+    var authorizationServerId: UUID? = null,
+    var keyType: String? = null,
+    var privateKey: String? = null,
+    var publicKey: String? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null,
+    var metadata: HashMap<String, Any>? = null
+) {
+    fun getAlgorithm(): String = "RS256"
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Template.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Template.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class Template(
+    var id: UUID? = null,
+    var authorizationServerId: UUID? = null,
+    var templateType: TemplateTypeEnum? = null,
+    var template: ByteArray? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/TemplateTypeEnum.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/TemplateTypeEnum.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+enum class TemplateTypeEnum(private val value: String) {
+    LOGIN("login");
+
+    fun value(): String = value
+
+    override fun toString(): String = value
+
+    companion object {
+        fun fromString(s: String): TemplateTypeEnum {
+            return values().find { it.value == s }
+                ?: throw IllegalArgumentException("Unexpected string value '$s'")
+        }
+
+        fun fromValue(value: String): TemplateTypeEnum {
+            return values().find { it.value == value }
+                ?: throw IllegalArgumentException("Unexpected value '$value'")
+        }
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/TokenTypeEnum.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/TokenTypeEnum.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+enum class TokenTypeEnum(private val value: String) {
+    BEARER("Bearer");
+
+    fun value(): String = value
+
+    override fun toString(): String = value
+
+    companion object {
+        /**
+         * Convert a String into String, as specified in the
+         * [See JAX RS 2.0 Specification, section 3.2, p. 12](https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html)
+         */
+        fun fromString(s: String): TokenTypeEnum {
+            return values().find { it.value == s }
+                ?: throw IllegalArgumentException("Unexpected string value '$s'")
+        }
+
+        fun fromValue(value: String): TokenTypeEnum {
+            return values().find { it.value == value }
+                ?: throw IllegalArgumentException("Unexpected value '$value'")
+        }
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/User.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/User.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import java.time.OffsetDateTime
+import java.util.*
+
+data class User(
+    var id: UUID? = null,
+    var authorizationServerId: UUID? = null,
+    var password: String? = null,
+    var username: String? = null,
+    var email: String? = null,
+    var metadata: Metadata? = null,
+    var createdOn: OffsetDateTime? = null,
+    var updatedOn: OffsetDateTime? = null
+) {
+    fun getProfile(): Any? = null
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/WellKnownEndpoints.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/WellKnownEndpoints.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class WellKnownEndpoints(
+    @JsonProperty("authorization_endpoint")
+    var authorizationEndpoint: String? = null,
+    
+    @JsonProperty("token_endpoint")
+    var tokenEndpoint: String? = null,
+    
+    @JsonProperty("userinfo_endpoint")
+    var userInfoEndpoint: String? = null,
+    
+    var issuer: String? = null,
+    
+    @JsonProperty("jwks_uri")
+    var jwksEndpoint: String? = null
+)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/NotAuthorized.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/NotAuthorized.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions
+
+class NotAuthorized : RuntimeException {
+    constructor(message: String) : super(message)
+    constructor() : super("The Application was not found")
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/ApplicationCreateProfileBadData.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/ApplicationCreateProfileBadData.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.badrequests
+
+class ApplicationCreateProfileBadData : RuntimeException("The Applications profile is not in the form of Map<String, Object>")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/ApplicationSecretNoApplicationBadData.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/ApplicationSecretNoApplicationBadData.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.badrequests
+
+class ApplicationSecretNoApplicationBadData : RuntimeException("Unable to find the Application with the credentials provided")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/CodeChallengeBadData.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/CodeChallengeBadData.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.badrequests
+
+class CodeChallengeBadData(message: String) : RuntimeException(message)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/WellKnownEndpointsFetchFailure.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/badrequests/WellKnownEndpointsFetchFailure.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.badrequests
+
+class WellKnownEndpointsFetchFailure(message: String) : Exception(message)

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ApplicationNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ApplicationNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class ApplicationNotFound : RuntimeException("The Application was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ApplicationSecretNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ApplicationSecretNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class ApplicationSecretNotFound : RuntimeException("The Application Secret was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/AuthorizationServerNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/AuthorizationServerNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class AuthorizationServerNotFound : RuntimeException("The Authorization Server was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ClientCodeNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ClientCodeNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class ClientCodeNotFound : RuntimeException("The ClientCode was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ClientNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ClientNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class ClientNotFound : RuntimeException("The Client was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/IdentityProviderNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/IdentityProviderNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class IdentityProviderNotFound : RuntimeException("The Identity Provider was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ProfileNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ProfileNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class ProfileNotFound : RuntimeException("The Profile was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/SchemaNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/SchemaNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class SchemaNotFound : RuntimeException("The Schema was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ScopeNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/ScopeNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class ScopeNotFound : RuntimeException("The Scope was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/TemplateNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/TemplateNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class TemplateNotFound : RuntimeException("The Template was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/UserNotFound.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/exceptions/notfound/UserNotFound.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.exceptions.notfound
+
+class UserNotFound : RuntimeException("The User was not found")

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ApplicationService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ApplicationService.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.Page
+import com.cartobucket.auth.data.domain.Pair
+import com.cartobucket.auth.data.exceptions.badrequests.ApplicationSecretNoApplicationBadData
+import com.cartobucket.auth.data.exceptions.notfound.ApplicationNotFound
+import com.cartobucket.auth.data.exceptions.notfound.ApplicationSecretNotFound
+import com.cartobucket.auth.data.exceptions.notfound.ProfileNotFound
+import com.cartobucket.auth.data.domain.Application
+import com.cartobucket.auth.data.domain.ApplicationSecret
+import com.cartobucket.auth.data.domain.Profile
+import java.util.*
+
+interface ApplicationService {
+
+    @Throws(ApplicationNotFound::class)
+    fun deleteApplication(applicationId: UUID)
+
+    @Throws(ApplicationNotFound::class, ProfileNotFound::class)
+    fun getApplication(applicationId: UUID): Pair<Application, Profile>
+
+    fun createApplication(application: Application, profile: Profile): Pair<Application, Profile>
+
+    @Throws(ApplicationNotFound::class)
+    fun getApplicationSecrets(applicationId: List<UUID>): List<ApplicationSecret>
+
+    @Throws(ApplicationNotFound::class)
+    fun createApplicationSecret(applicationSecret: ApplicationSecret): ApplicationSecret
+
+    @Throws(ApplicationSecretNoApplicationBadData::class, ApplicationSecretNotFound::class)
+    fun deleteApplicationSecret(secretId: UUID)
+
+    fun getApplications(authorizationServerIds: List<UUID>, page: Page): List<Application>
+
+    fun isApplicationSecretValid(authorizationServerId: UUID, applicationId: UUID, applicationSecret: String): Boolean
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/AuthorizationServerService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/AuthorizationServerService.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.AccessToken
+import com.cartobucket.auth.data.domain.AuthorizationServer
+import com.cartobucket.auth.data.domain.JWK
+import com.cartobucket.auth.data.domain.Page
+import com.cartobucket.auth.data.domain.Scope
+import com.cartobucket.auth.data.domain.SigningKey
+import com.cartobucket.auth.data.exceptions.NotAuthorized
+import com.cartobucket.auth.data.exceptions.notfound.AuthorizationServerNotFound
+import java.util.UUID
+
+interface AuthorizationServerService {
+    // This method returns the actual AuthorizationServer object as it is a dependency of the rest of the system.
+    @Throws(AuthorizationServerNotFound::class)
+    fun getAuthorizationServer(authorizationServerId: UUID): AuthorizationServer
+
+    fun createAuthorizationServer(authorizationServer: AuthorizationServer): AuthorizationServer
+
+    @Throws(AuthorizationServerNotFound::class)
+    fun updateAuthorizationServer(authorizationServerId: UUID, authorizationServer: AuthorizationServer): AuthorizationServer
+
+    fun getAuthorizationServers(page: Page): List<AuthorizationServer>
+
+    @Throws(AuthorizationServerNotFound::class)
+    fun deleteAuthorizationServer(authorizationServerId: UUID)
+
+    fun getSigningKeysForAuthorizationServer(authorizationServerId: UUID): SigningKey
+
+    @Throws(NotAuthorized::class)
+    fun validateJwtForAuthorizationServer(authorizationServerId: UUID, jwt: String): Map<String, Any>
+
+    fun getJwksForAuthorizationServer(authorizationServerId: UUID): List<JWK>
+
+    fun generateAccessToken(
+        authorizationServerId: UUID,
+        userId: UUID,
+        subject: String,
+        scopes: List<Scope>,
+        expireInSeconds: Long,
+        nonce: String
+    ): AccessToken
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ClientService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ClientService.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.Client
+import com.cartobucket.auth.data.domain.ClientCode
+import com.cartobucket.auth.data.domain.Page
+import com.cartobucket.auth.data.exceptions.notfound.ClientCodeNotFound
+import com.cartobucket.auth.data.exceptions.notfound.ClientNotFound
+import java.util.UUID
+
+interface ClientService {
+    fun createClient(client: Client): Client
+
+    @Throws(ClientNotFound::class)
+    fun getClient(clientId: String): Client
+
+    fun getClients(authorizationServerIds: List<UUID>, page: Page): List<Client>
+
+    @Throws(ClientNotFound::class)
+    fun deleteClient(clientId: UUID)
+
+    @Throws(ClientNotFound::class)
+    fun updateClient(clientId: UUID, client: Client): Client
+
+    fun createClientCode(authorizationServerId: UUID, clientCode: ClientCode): ClientCode
+
+    @Throws(ClientCodeNotFound::class)
+    fun getClientCode(clientCode: String): ClientCode
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/IdentityProviderService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/IdentityProviderService.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.IdentityProvider
+import com.cartobucket.auth.data.domain.WellKnownEndpoints
+import com.cartobucket.auth.data.exceptions.badrequests.WellKnownEndpointsFetchFailure
+import com.cartobucket.auth.data.exceptions.notfound.IdentityProviderNotFound
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.UUID
+
+interface IdentityProviderService {
+    @Throws(IdentityProviderNotFound::class)
+    fun deleteIdentityProvider(identityProviderId: UUID)
+
+    @Throws(IdentityProviderNotFound::class)
+    fun getIdentityProvider(identityProviderId: UUID): IdentityProvider
+
+    fun createIdentityProvider(identityProvider: IdentityProvider): IdentityProvider
+
+    @Throws(IdentityProviderNotFound::class)
+    fun updateIdentityProvider(identityProviderId: UUID, identityProvider: IdentityProvider): IdentityProvider
+
+    @Throws(WellKnownEndpointsFetchFailure::class)
+    fun fetchWellKnownEndpoints(discoveryEndpoint: String): WellKnownEndpoints {
+        return try {
+            HttpClient.newBuilder().build().use { client ->
+                val response = client.send(
+                    HttpRequest.newBuilder()
+                        .GET()
+                        .uri(URI.create(discoveryEndpoint))
+                        .header("Accept", "application/json")
+                        .timeout(Duration.ofSeconds(60))
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString()
+                )
+                if (response.statusCode() != 200) {
+                    throw WellKnownEndpointsFetchFailure(response.body())
+                }
+
+                ObjectMapper().readValue(response.body(), WellKnownEndpoints::class.java)
+            }
+        } catch (e: IOException) {
+            throw WellKnownEndpointsFetchFailure(e.message)
+        } catch (e: InterruptedException) {
+            throw WellKnownEndpointsFetchFailure(e.message)
+        }
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/SchemaService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/SchemaService.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.Page
+import com.cartobucket.auth.data.domain.Profile
+import com.cartobucket.auth.data.domain.Schema
+import com.cartobucket.auth.data.exceptions.notfound.SchemaNotFound
+import java.util.UUID
+
+interface SchemaService {
+    fun validateProfileAgainstSchema(profile: Profile, schema: Schema): Set<String>
+
+    fun createSchema(schema: Schema): Schema
+
+    @Throws(SchemaNotFound::class)
+    fun deleteSchema(schemaId: UUID)
+
+    @Throws(SchemaNotFound::class)
+    fun getSchema(schemaId: UUID): Schema
+
+    fun getSchemas(authorizationServerIds: List<UUID>, page: Page): List<Schema>
+
+    @Throws(SchemaNotFound::class)
+    fun updateSchema(schemaId: UUID, schema: Schema): Schema
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ScopeService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ScopeService.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.Page
+import com.cartobucket.auth.data.domain.Scope
+import com.cartobucket.auth.data.exceptions.notfound.ScopeNotFound
+import java.util.UUID
+
+interface ScopeService {
+    fun getScopes(authorizationServerIds: List<UUID>, page: Page): List<Scope>
+
+    fun createScope(scope: Scope): Scope
+
+    @Throws(ScopeNotFound::class)
+    fun deleteScope(scopeId: UUID)
+
+    @Throws(ScopeNotFound::class)
+    fun getScope(scopeId: UUID): Scope
+
+    // Takes in a list of scopes and filters those scopes based on what scopes are associated with the AS.
+    fun filterScopesForAuthorizationServerId(authorizationServerId: UUID, scopes: String): List<Scope>
+
+    fun getScopesForResourceId(id: UUID): List<Scope>
+
+    companion object {
+        @JvmStatic
+        fun scopeStringToScopeList(scopes: String?): List<Scope> {
+            if (scopes == null) {
+                return emptyList()
+            }
+
+            val splitScopes = scopes.split("\\p{Zs}+".toRegex())
+
+            return splitScopes.map { scopeName ->
+                Scope().apply { name = scopeName }
+            }
+        }
+
+        @JvmStatic
+        fun scopeListToScopeString(scopes: List<String>): String {
+            return scopes.joinToString(" ")
+        }
+
+        @JvmStatic
+        fun filterScopesByList(scopes: String?, authorizationServerScopes: List<String>?): List<Scope> {
+            if (scopes == null || authorizationServerScopes == null) {
+                return emptyList()
+            }
+            return scopeStringToScopeList(scopes)
+                .map { it.name }
+                .filter { authorizationServerScopes.contains(it) }
+                .map { scopeName ->
+                    Scope().apply { name = scopeName }
+                }
+        }
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/TemplateService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/TemplateService.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.Page
+import com.cartobucket.auth.data.domain.Template
+import com.cartobucket.auth.data.exceptions.notfound.TemplateNotFound
+import java.util.UUID
+
+interface TemplateService {
+    fun getTemplates(authorizationServerIds: List<UUID>, page: Page): List<Template>
+
+    fun createTemplate(template: Template): Template
+
+    @Throws(TemplateNotFound::class)
+    fun deleteTemplate(templateId: UUID)
+
+    @Throws(TemplateNotFound::class)
+    fun getTemplate(templateId: UUID): Template
+
+    //    fun getTemplateForAuthorizationServer(authorizationServer: UUID, templateType: TemplateTypeEnum): Template
+
+    @Throws(TemplateNotFound::class)
+    fun updateTemplate(templateId: UUID, template: Template): Template
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/UserService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/UserService.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.data.services
+
+import com.cartobucket.auth.data.domain.Identifier
+import com.cartobucket.auth.data.domain.Pair
+import com.cartobucket.auth.data.domain.Profile
+import com.cartobucket.auth.data.domain.SchemaValidation
+import com.cartobucket.auth.data.domain.User
+import com.cartobucket.auth.data.exceptions.notfound.ProfileNotFound
+import com.cartobucket.auth.data.exceptions.notfound.UserNotFound
+import java.util.UUID
+
+interface UserService {
+    data class Page(
+        val limit: Int,
+        val offset: Int
+    )
+
+    data class UserQuery(
+        val authorizationServerIds: List<UUID>,
+        val userIds: List<UUID>,
+        val emails: List<String>,
+        val identifiers: List<Identifier>,
+        val validations: List<SchemaValidation>,
+        val page: Page
+    )
+
+    fun query(query: UserQuery): List<User>
+
+    fun getUsers(authorizationServerIds: List<UUID>, page: com.cartobucket.auth.data.domain.Page): List<User>
+
+    fun createUser(userProfilePair: Pair<User, Profile>): Pair<User, Profile>
+
+    fun deleteUser(userId: UUID)
+
+    @Throws(UserNotFound::class, ProfileNotFound::class)
+    fun getUser(userId: UUID): Pair<User, Profile>
+
+    @Throws(UserNotFound::class, ProfileNotFound::class)
+    fun getUser(username: String): Pair<User, Profile>
+
+    @Throws(UserNotFound::class, ProfileNotFound::class)
+    fun updateUser(userId: UUID, userProfilePair: Pair<User, Profile>): Pair<User, Profile>
+
+    fun setPassword(user: User, password: String)
+
+    fun validatePassword(userId: UUID, password: String): Boolean
+}


### PR DESCRIPTION
  Conversion Complete ✅

  Summary:
  - 47 Kotlin files created in total
  - 21 Java domain classes converted to Kotlin
  - All Java source files removed from the module
  - Build configuration updated for Kotlin support

  Key conversions:
  - Simple data classes → Kotlin data classes with nullable properties
  - Record classes → Kotlin data classes with validation
  - Enum classes → Kotlin enum classes with companion objects
  - Builder patterns → Simplified data classes (per your instruction)
  - Jackson annotations and special methods preserved where needed

  The module now fully supports Kotlin development while maintaining API compatibility.
