### PR TITLE
feat: add refresh token support to the authorization code flow.

### DIFF
--- a/auth-authorization-server-api/src/main/openapi/api.json
+++ b/auth-authorization-server-api/src/main/openapi/api.json
@@ -755,8 +755,13 @@
           "grant_type": {
             "enum": [
               "client_credentials",
-              "authorization_code"
+              "authorization_code",
+              "refresh_token"
             ],
+            "type": "string"
+          },
+          "refresh_token": {
+            "description": "The refresh token to use for obtaining a new access token",
             "type": "string"
           },
           "code": {

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/entities/RefreshToken.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/entities/RefreshToken.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.postgres.client.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken extends PanacheEntityBase {
+    @Id
+    @GeneratedValue
+    public UUID id;
+
+    @Column(name = "token_hash", nullable = false, unique = true)
+    public String tokenHash;
+
+    @Column(name = "user_id", nullable = false)
+    public UUID userId;
+
+    @Column(name = "client_id", nullable = false)
+    public String clientId;
+
+    @Column(name = "authorization_server_id", nullable = false)
+    public UUID authorizationServerId;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "scopes", columnDefinition = "jsonb")
+    public List<String> scopes;
+
+    @Column(name = "expires_at", nullable = false)
+    public OffsetDateTime expiresAt;
+
+    @Column(name = "created_on", nullable = false)
+    public OffsetDateTime createdOn;
+
+    @Column(name = "is_revoked", nullable = false)
+    public boolean isRevoked = false;
+
+    @Column(name = "revoked_at")
+    public OffsetDateTime revokedAt;
+}

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/RefreshTokenRepository.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/RefreshTokenRepository.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Bryce Groff (Cartobucket LLC)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cartobucket.auth.postgres.client.repositories;
+
+import com.cartobucket.auth.postgres.client.entities.RefreshToken;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class RefreshTokenRepository implements PanacheRepositoryBase<RefreshToken, UUID> {
+    
+    public Optional<RefreshToken> findByTokenHash(String tokenHash) {
+        return find("tokenHash = ?1 and isRevoked = false and expiresAt > ?2", 
+                    tokenHash, OffsetDateTime.now())
+                .firstResultOptional();
+    }
+    
+    public void revokeToken(String tokenHash) {
+        update("isRevoked = true, revokedAt = ?1 where tokenHash = ?2", 
+               OffsetDateTime.now(), tokenHash);
+    }
+    
+    public void revokeAllUserTokens(UUID userId) {
+        update("isRevoked = true, revokedAt = ?1 where userId = ?2 and isRevoked = false", 
+               OffsetDateTime.now(), userId);
+    }
+    
+    public void deleteExpiredTokens() {
+        delete("expiresAt < ?1", OffsetDateTime.now());
+    }
+}

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/AuthorizationServerService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/AuthorizationServerService.kt
@@ -59,4 +59,10 @@ interface AuthorizationServerService {
         expireInSeconds: Long,
         nonce: String
     ): AccessToken
+    
+    fun refreshAccessToken(
+        authorizationServerId: UUID,
+        refreshToken: String,
+        clientId: String
+    ): AccessToken
 }


### PR DESCRIPTION
  Add Refresh Token Support to Authorization Code Flow

  Summary

  This PR implements refresh token functionality for the OAuth 2.0 authorization code flow, enabling long-lived authentication sessions through token rotation.

  Changes

  New Features

  - Refresh Token Entity & Repository: Added RefreshToken.java entity and RefreshTokenRepository.java for secure refresh token storage with:
    - Token hashing (SHA-256) for security
    - Expiration tracking (30-day default)
    - Token revocation support
    - Automatic cleanup of expired tokens

  Authorization Server Updates

  - Grant Type Support: Added refresh_token grant type to well-known endpoint and token issuance
  - Scope Validation: Implemented proper scope validation for offline_access requests
  - Token Rotation: Implemented secure token rotation - old refresh tokens are immediately revoked when used
  - Client Validation: Added client ID and authorization server ID verification during refresh

  API Changes

  - Updated OpenAPI spec to include refresh_token field in AccessTokenRequest
  - Modified token endpoint to handle refresh token requests with proper validation

  Security Considerations

  - Refresh tokens are hashed before storage (no plaintext tokens in database)
  - Automatic token rotation prevents replay attacks
  - Client ID verification ensures tokens can't be used by unauthorized clients
  - 30-day expiration for refresh tokens with cleanup support

  Testing Checklist

  - Test authorization code flow with offline_access scope
  - Verify refresh token is issued only when offline_access is requested
  - Test refresh token rotation (old token revoked after use)
  - Verify client ID mismatch rejection
  - Test expired refresh token rejection
  - Verify access token generation from refresh token maintains correct scopes
