### PR TITLE
add schema validation to the profile using a default oidc userinfo schema

### DIFF
--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/entities/Schema.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/entities/Schema.java
@@ -24,6 +24,8 @@ import com.networknt.schema.SpecVersion;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -32,6 +34,9 @@ import java.util.Map;
 import java.util.UUID;
 
 @Entity
+@Table(uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"name", "authorizationServerId"})
+})
 public class Schema {
     @Id
     @GeneratedValue

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/ApplicationRepository.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/ApplicationRepository.java
@@ -23,8 +23,12 @@ import com.cartobucket.auth.postgres.client.entities.Application;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @ApplicationScoped
 public class ApplicationRepository implements PanacheRepositoryBase<Application, UUID> {
+    public Optional<Application> findByClientIdAndAuthorizationServerId(String clientId, UUID authorizationServerId) {
+        return find("clientId = ?1 and authorizationServerId = ?2", clientId, authorizationServerId).firstResultOptional();
+    }
 }

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/ApplicationSecretRepository.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/ApplicationSecretRepository.java
@@ -15,6 +15,6 @@ public class ApplicationSecretRepository implements PanacheRepositoryBase<Applic
     }
 
     public Optional<ApplicationSecret> findByApplicationSecretHash(String secretHash) {
-        return find("secretHash = ?1", secretHash).singleResultOptional();
+        return find("applicationSecretHash = ?1", secretHash).singleResultOptional();
     }
 }

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/SchemaRepository.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/repositories/SchemaRepository.java
@@ -25,12 +25,17 @@ import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @ApplicationScoped
 public class SchemaRepository implements PanacheRepositoryBase<Schema, UUID> {
     public List<Schema> findAllByAuthorizationServerIdIn(List<UUID> authorizationServerIds) {
         return find("authorizationServerId in ?1", authorizationServerIds).list();
+    }
+    
+    public Optional<Schema> findByNameAndAuthorizationServerId(String name, UUID authorizationServerId) {
+        return find("name = ?1 and authorizationServerId = ?2", name, authorizationServerId).firstResultOptional();
     }
 
 }

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/services/AuthorizationServerService.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/services/AuthorizationServerService.java
@@ -19,8 +19,20 @@
 
 package com.cartobucket.auth.postgres.client.services;
 
-import com.cartobucket.auth.data.domain.*;
+import com.cartobucket.auth.data.domain.AccessToken;
+import com.cartobucket.auth.data.domain.AuthorizationServer;
+import com.cartobucket.auth.data.domain.JWK;
+import com.cartobucket.auth.data.domain.Metadata;
+import com.cartobucket.auth.data.domain.Page;
+import com.cartobucket.auth.data.domain.Profile;
+import com.cartobucket.auth.data.domain.Schema;
+import com.cartobucket.auth.data.domain.Scope;
+import com.cartobucket.auth.data.domain.SigningKey;
+import com.cartobucket.auth.data.domain.Template;
+import com.cartobucket.auth.data.domain.TemplateTypeEnum;
+import com.cartobucket.auth.data.domain.TokenTypeEnum;
 import com.cartobucket.auth.data.exceptions.NotAuthorized;
+import com.cartobucket.auth.data.exceptions.TokenGenerationException;
 import com.cartobucket.auth.data.exceptions.notfound.AuthorizationServerNotFound;
 import com.cartobucket.auth.data.exceptions.notfound.ProfileNotFound;
 import com.cartobucket.auth.data.services.ScopeService;
@@ -44,6 +56,7 @@ import io.smallrye.jwt.build.Jwt;
 import io.smallrye.jwt.util.KeyUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
 import org.jose4j.jwa.AlgorithmConstraints;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jwt.JwtClaims;
@@ -74,6 +87,8 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class AuthorizationServerService implements com.cartobucket.auth.data.services.AuthorizationServerService {
+    private static final Logger LOG = Logger.getLogger(AuthorizationServerService.class);
+    
     final AuthorizationServerRepository authorizationServerRepository;
     final ApplicationSecretRepository applicationSecretRepository;
     final EventRepository eventRepository;
@@ -575,7 +590,7 @@ public class AuthorizationServerService implements com.cartobucket.auth.data.ser
             }
         } catch (IOException e) {
             // Log warning but don't fail authorization server creation if schema creation fails
-            System.err.println("Warning: Could not create OIDC UserInfo claims schema: " + e.getMessage());
+            LOG.warn("Could not create OIDC UserInfo claims schema: " + e.getMessage(), e);
         }
     }
 
@@ -612,7 +627,7 @@ public class AuthorizationServerService implements com.cartobucket.auth.data.ser
             accessToken.setScope((String) additionalClaims.get("scope"));
             return accessToken;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new TokenGenerationException("Failed to generate access token", e);
         }
     }
     
@@ -649,7 +664,7 @@ public class AuthorizationServerService implements com.cartobucket.auth.data.ser
             accessToken.setScope((String) additionalClaims.get("scope"));
             return accessToken;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new TokenGenerationException("Failed to generate client credentials access token", e);
         }
     }
 }

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/services/SchemaService.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/services/SchemaService.java
@@ -125,6 +125,13 @@ public class SchemaService implements com.cartobucket.auth.data.services.SchemaS
     }
 
     @Override
+    public Schema getSchemaByNameAndAuthorizationServerId(String name, UUID authorizationServerId) {
+        return schemaRepository.findByNameAndAuthorizationServerId(name, authorizationServerId)
+                .map(SchemaMapper::from)
+                .orElse(null);
+    }
+
+    @Override
     @Transactional
     public Schema updateSchema(final UUID schemaId, Schema schema) throws SchemaNotFound {
         var _schema = schemaRepository

--- a/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/services/UserService.java
+++ b/auth-data-postgres-client/src/main/java/com/cartobucket/auth/postgres/client/services/UserService.java
@@ -39,6 +39,7 @@ import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.OffsetDateTime;
@@ -47,6 +48,8 @@ import java.util.UUID;
 
 @ApplicationScoped
 public class UserService implements com.cartobucket.auth.data.services.UserService {
+    private static final Logger LOG = Logger.getLogger(UserService.class);
+    
     final EventRepository eventRepository;
     final UserRepository userRepository;
     final ProfileRepository profileRepository;
@@ -287,7 +290,7 @@ public class UserService implements com.cartobucket.auth.data.services.UserServi
             }
         } catch (Exception e) {
             // Log warning but don't fail user creation if validation fails
-            System.err.println("Warning: Could not validate profile against OIDC schema: " + e.getMessage());
+            LOG.warn("Could not validate profile against OIDC schema: " + e.getMessage(), e);
         }
     }
 }

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Scope.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/domain/Scope.kt
@@ -28,14 +28,14 @@ data class Scope(
     var name: String? = null,
     var metadata: Metadata? = null,
     var createdOn: OffsetDateTime? = null,
-    var updatedOn: OffsetDateTime? = null
+    var updatedOn: OffsetDateTime? = null,
 ) {
     constructor(id: UUID) : this(id, null, null, null, null, null)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other == null || this::class != other::class) return false
-        other as Scope
-        return name == other.name
+        if (this.id == null || other !is Scope || other.id == null) return false
+        return this.id == other.id
     }
 
     override fun hashCode(): Int = name?.hashCode() ?: 0

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ApplicationService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/ApplicationService.kt
@@ -51,5 +51,7 @@ interface ApplicationService {
 
     fun getApplications(authorizationServerIds: List<UUID>, page: Page): List<Application>
 
-    fun isApplicationSecretValid(authorizationServerId: UUID, applicationId: UUID, applicationSecret: String): Boolean
+    fun isApplicationSecretValid(authorizationServerId: UUID, applicationSecretId: UUID, applicationSecret: String): Boolean
+    
+    fun getApplicationSecret(applicationSecretId: String): ApplicationSecret
 }

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/AuthorizationServerService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/AuthorizationServerService.kt
@@ -51,23 +51,22 @@ interface AuthorizationServerService {
 
     fun getJwksForAuthorizationServer(authorizationServerId: UUID): List<JWK>
 
-    fun generateAccessToken(
+    fun generateClientCredentialsAccessToken(
         authorizationServerId: UUID,
-        userId: UUID,
+        applicationId: UUID,
         subject: String,
         scopes: List<Scope>,
-        expireInSeconds: Long,
-        nonce: String
+        expiresInSeconds: Long
     ): AccessToken
     
-    fun generateAccessTokenWithClientId(
+    fun generateAuthorizationCodeFlowAccessToken(
         authorizationServerId: UUID,
         userId: UUID,
         subject: String,
         clientId: String,
         scopes: List<Scope>,
-        expireInSeconds: Long,
-        nonce: String
+        expiresInSeconds: Long,
+        nonce: String?
     ): AccessToken
     
     fun refreshAccessToken(

--- a/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/SchemaService.kt
+++ b/auth-data/src/main/kotlin/com/cartobucket/auth/data/services/SchemaService.kt
@@ -38,6 +38,8 @@ interface SchemaService {
 
     fun getSchemas(authorizationServerIds: List<UUID>, page: Page): List<Schema>
 
+    fun getSchemaByNameAndAuthorizationServerId(name: String, authorizationServerId: UUID): Schema?
+
     @Throws(SchemaNotFound::class)
     fun updateSchema(schemaId: UUID, schema: Schema): Schema
 }

--- a/auth-data/src/main/resources/schemas/oidc-userinfo-claims.json
+++ b/auth-data/src/main/resources/schemas/oidc-userinfo-claims.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OIDC UserInfo Claims Schema",
+  "description": "Schema for validating OpenID Connect UserInfo claims stored in Profile.profile field",
+  "type": "object",
+  "properties": {
+    "sub": {
+      "type": "string",
+      "description": "Subject - Identifier for the End-User at the Issuer"
+    },
+    "name": {
+      "type": "string",
+      "description": "End-User's full name in displayable form"
+    },
+    "given_name": {
+      "type": "string",
+      "description": "Given name(s) or first name(s) of the End-User"
+    },
+    "family_name": {
+      "type": "string",
+      "description": "Surname(s) or last name(s) of the End-User"
+    },
+    "middle_name": {
+      "type": "string",
+      "description": "Middle name(s) of the End-User"
+    },
+    "nickname": {
+      "type": "string",
+      "description": "Casual name of the End-User"
+    },
+    "preferred_username": {
+      "type": "string",
+      "description": "Shorthand name by which the End-User wishes to be referred"
+    },
+    "profile": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the End-User's profile page"
+    },
+    "picture": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the End-User's profile picture"
+    },
+    "website": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the End-User's Web page or blog"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "End-User's preferred e-mail address"
+    },
+    "email_verified": {
+      "type": "boolean",
+      "description": "True if the End-User's e-mail address has been verified"
+    },
+    "gender": {
+      "type": "string",
+      "description": "End-User's gender"
+    },
+    "birthdate": {
+      "type": "string",
+      "format": "date",
+      "description": "End-User's birthday, represented as an ISO 8601:2004 YYYY-MM-DD format"
+    },
+    "zoneinfo": {
+      "type": "string",
+      "description": "String from zoneinfo time zone database representing the End-User's time zone"
+    },
+    "locale": {
+      "type": "string",
+      "description": "End-User's locale, represented as a BCP47 language tag"
+    },
+    "phone_number": {
+      "type": "string",
+      "description": "End-User's preferred telephone number"
+    },
+    "phone_number_verified": {
+      "type": "boolean",
+      "description": "True if the End-User's phone number has been verified"
+    },
+    "address": {
+      "type": "object",
+      "description": "End-User's preferred postal address",
+      "properties": {
+        "formatted": {
+          "type": "string",
+          "description": "Full mailing address, formatted for display"
+        },
+        "street_address": {
+          "type": "string",
+          "description": "Full street address component"
+        },
+        "locality": {
+          "type": "string",
+          "description": "City or locality component"
+        },
+        "region": {
+          "type": "string",
+          "description": "State, province, prefecture, or region component"
+        },
+        "postal_code": {
+          "type": "string",
+          "description": "Zip code or postal code component"
+        },
+        "country": {
+          "type": "string",
+          "description": "Country name component"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "integer",
+      "description": "Time the End-User's information was last updated (seconds since Unix epoch)"
+    }
+  },
+  "additionalProperties": true,
+  "required": []
+}


### PR DESCRIPTION
  Implementation Summary

  ✅ Created OIDC Schema File
  - Added /auth-data/src/main/resources/schemas/oidc-userinfo-claims.json with comprehensive OIDC UserInfo claims schema
  - Schema includes all standard OIDC claims: sub, name, given_name, family_name, email, picture, etc.
  - Uses JSON Schema Draft 2020-12 with flexible validation (no required fields, allows additional properties)

  ✅ Enhanced Authorization Server Creation
  - Modified AuthorizationServerService.java:580 to inject SchemaService
  - Added createDefaultSchemasForAuthorizationServer() method that loads and creates the OIDC schema when an authorization server is created
  - Integrated schema creation into the authorization server setup workflow at AuthorizationServerService.java:373

  ✅ Enhanced User Creation with Profile Validation
  - Modified UserService.java:49 to inject SchemaService
  - Added profile validation to createUser() method at UserService.java:144
  - Implemented validateAndStoreSchemaValidation() method at UserService.java:248 that:
    - Finds the OIDC schema for the authorization server
    - Validates the user's profile data against the schema
    - Stores validation results in profile.metadata.schemaValidations
    - Records validation timestamp and success/failure status

  How It Works

  1. When an Authorization Server is created: The system automatically creates an OIDC UserInfo claims schema for that authorization server
  2. When a User is created: The system validates the user's profile data against the OIDC schema and stores the validation results in the profile's metadata
  3. Schema Validation Storage: Results are stored in the SchemaValidation objects within Profile.metadata.schemaValidations, tracking which schema was used, whether validation passed, and when it was
  validated

  The implementation is robust with proper error handling - schema creation or validation failures won't prevent authorization server or user creation, but will log warnings for monitoring.


Round 2

. Root Cause Identified

  - You discovered that authorization code flow was broken after recent refactors
  - Refresh tokens were failing immediately after being issued
  - The issue was in the generateAccessToken method which was treating all userId parameters as ApplicationSecret IDs

  2. Method Refactoring

  - Created two dedicated methods to replace the confusing single generateAccessToken:
    - generateClientCredentialsAccessToken() - for machine-to-machine auth
    - generateAuthorizationCodeFlowAccessToken() - for user authentication
  - Removed the old generateAccessTokenWithClientId() method

  3. Interface Updates

  - Updated AuthorizationServerService.kt interface to define the two new methods
  - Each method has clear, specific parameters for its flow type

  4. Implementation Details

  Client Credentials Flow (generateClientCredentialsAccessToken):
  - Takes applicationId directly (not ApplicationSecret ID)
  - No refresh tokens generated
  - No ID tokens included
  - Fixed: Removed hardcoded "openid" scope (only includes scopes if provided)

  Authorization Code Flow (generateAuthorizationCodeFlowAccessToken):
  - Takes userId (actual User ID)
  - Generates refresh tokens (30-day expiration)
  - Includes ID tokens
  - Properly stores refresh tokens in database

  5. Routes Updated

  - Modified AuthorizationServer.java switch statement to use the new dedicated methods
  - Added getApplicationSecret() method to ApplicationService to support the routes

  6. Key Fixes

  - Refresh tokens now work correctly for authorization code flow
  - Client credentials flow no longer tries to generate refresh tokens
  - Parameter confusion eliminated (clear what each ID represents)
  - OpenID scope no longer incorrectly added to client credentials responses

  The code is now much cleaner with clear separation between the two OAuth flows, eliminating the parameter confusion that was causing the refresh token failures.
